### PR TITLE
Fixed two bugs involving water coin tiles

### DIFF
--- a/src/enemies.c
+++ b/src/enemies.c
@@ -309,6 +309,7 @@ void get_enemies(void) {
         uint8_t *this = tilemap.map + j;
         uint8_t tile = *this;
         int8_t tmp1, tmp2;
+        uint8_t *tile_pntr;
 
         switch(tile) {
             // this case is just to avoid another function that converts coins in water to water coins
@@ -317,8 +318,11 @@ void get_enemies(void) {
                     int off = tmp2 * width;
                     bool at_neg_1 = tmp2 == -1;
                     for (tmp1=-1; tmp1<2; tmp1++) {
-                        tile = *(this+tmp1+off);
+                        tile_pntr = (this+tmp1+off);
+                        tile = *tile_pntr;
                         if (tile == TILE_WATER || tile == TILE_WATER_COIN || (at_neg_1 && tile == TILE_WATER_TOP)) {
+                            if ((tile_pntr < tilemap.map) || (tile_pntr > tilemap.map + loop)) continue; // prevents checking outside tilemap
+                            if (abs((j % width) - ((tile_pntr - tilemap.map) % width)) > 1) continue; // prevents checking other side
                             *this = TILE_WATER_COIN;
                             goto end_loops;
                         }


### PR DESCRIPTION
I love this game! While I was playing around with it, I noticed some strange behavior with water coins. I think I found a fix.

### Bug 1:
Sometimes coins in the top (and bottom) row of a level will get turned into water coins. This means when you collect the coin, a water tile is left behind. I have observed this bug on both an emulator and a physical calculator with the latest version of Oiram. The bug can be reproduced on levels 3, 5, and 9 of the default pack. I have also been able to reproduce this bug in custom levels with a large width and coins on the top row.

To reproduce the bug in the default pack, load one of the affected levels at least 2-3 times in a row. The next time you load the level, the affected coins will be turned into water coins.

The following clip is from level 3:
![bug](https://user-images.githubusercontent.com/28833128/70197358-374d2500-16d1-11ea-9b74-8f45200a8cbf.gif)

**For visibility, I have changed `enemies.c` so that it turns coins into wood tiles instead of water coins in the rest of my screenshots.**

I believe this bug is caused when the game is checking the tiles around a coin for water. If the coin is on the top (or bottom) row of a level, the game is reading a memory location outside of the tilemap. If that memory location happens to be `26` (the value of water tiles) then it thinks the coin is touching water and should be a water coin. My patch fixes this bug by skipping any check that reads a memory location outside of the tilemap.

[These are the three coins that get turned into water coins. They then cause the other coins to be converted]
![withoutfix1](https://user-images.githubusercontent.com/28833128/70197836-b4c56500-16d2-11ea-863a-8a05227af72e.png)

[With the patch]
![withfix1](https://user-images.githubusercontent.com/28833128/70198163-b17ea900-16d3-11ea-8373-1c5178bc1b02.png)

### Bug 2:
Because of the way the tilemap is laid out in memory, the test for water tiles can loop around to the opposite side of the level. This affects the leftmost and rightmost column in a level. I haven't noticed this in any of the default pack levels, but I was able to recreate it in a custom level.

[Current Oiram. Water tile causes coins in leftmost column to become water coins]
![withoutfix2](https://user-images.githubusercontent.com/28833128/70198780-71202a80-16d5-11ea-814b-0f48b9f042d6.png)

[With the patch]
![withfix2](https://user-images.githubusercontent.com/28833128/70198815-8dbc6280-16d5-11ea-8d46-dca566b87d56.png)

For convenience, I included a .zip file with the custom level to test this bug and a build of Oiram that creates wood tiles instead of water coin tiles.
[water-coin-bug.zip](https://github.com/mateoconlechuga/oiram/files/3924855/water-coin-bug.zip)

This is my favorite calculator game. I hope I was able to contribute something useful!
