### PR TITLE
Fix timers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -310,9 +310,8 @@ HANDLE_DRAW_LEVEL:
     delay(400);
 
     // set up the timer
-    timer_Control = TIMER1_DISABLE;
     timer_1_ReloadValue = timer_1_Counter = 32768;
-    timer_Control = TIMER1_ENABLE | TIMER1_32K | TIMER1_0INT | TIMER1_DOWN;
+    timer_Enable(1, TIMER_32K, TIMER_0INT, TIMER_DOWN);
 
     // setup keypad handlers
     if (game.alternate_keypad) {
@@ -363,7 +362,7 @@ HANDLE_DRAW_LEVEL:
         }
     }
 
-    timer_Control = TIMER1_DISABLE;
+    timer_Disable(1);
 
     // deallocate
     while(num_simple_enemies) { remove_simple_enemy(0); }

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ void handler_clock(void) {
 
 // checks if a full second has elapsed and calls the clock handler if so
 void handle_clock(void) {
-    if (clock() >= clock_next) {
+    if ((int)clock() - (int)clock_next >= 0) {
         handler_clock();
         clock_next += CLOCKS_PER_SEC;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -54,23 +54,16 @@ void handler_clock(void) {
             show_blue_items(false);
         }
     }
-}
-
-// handles however many seconds have elapsed since last called
-void handle_clock(void) {
-    unsigned int clock_now;
-
-    clock_now = clock();
-    if (clock_now < clock_next) {
-        return;
-    }
-
-    do {
-        handler_clock();
-        clock_next += CLOCKS_PER_SEC;
-    } while (clock_now >= clock_next);
 
     draw_time();
+}
+
+// checks if a full second has elapsed and calls the clock handler if so
+void handle_clock(void) {
+    if (clock() >= clock_next) {
+        handler_clock();
+        clock_next += CLOCKS_PER_SEC;
+    }
 }
 
 // called when user presses or releases a key


### PR DESCRIPTION
Fixes #17.

The introduction of the always-running clock in https://github.com/CE-Programming/toolchain/pull/325 conflicted with Oiram's use of timers. Not because they used the same timer, but because Oiram simply clobbered (disabled) the other timers when configuring its own. After doing so, the next usage of `delay()` would cause a freeze because the clock was stopped.

Initially I simply fixed Oiram's timer usage not to clobber the other timers, which fixed the issue. But while I was at it, I switched Oiram to use `clock()` checking instead of using a timer. The resulting code is more portable (lol) and happens to save 42 bytes in the compressed program.